### PR TITLE
[qr-filter] Migrate to Zxing 2.0 and enable inverted QR code. JB#58962

### DIFF
--- a/rpm/qr-filter-qml-plugin.spec
+++ b/rpm/qr-filter-qml-plugin.spec
@@ -1,6 +1,6 @@
 Name:       qr-filter-qml-plugin
 Summary:    QR code qml wrappper based on ZXing
-Version:    1.0
+Version:    1.1
 Release:    1
 License:    ASL 2.0
 URL:        https://github.com/sailfishos/qr-filter-qml-plugin
@@ -9,7 +9,7 @@ BuildRequires: pkgconfig(Qt5Core)
 BuildRequires: pkgconfig(Qt5Quick)
 BuildRequires: pkgconfig(Qt5Multimedia)
 BuildRequires: pkgconfig(Qt5DBus)
-BuildRequires: pkgconfig(zxing) >= 1.1.0
+BuildRequires: pkgconfig(zxing) >= 2.0.0
 
 %description
 QML zxing wrapper with filter for QR-code reading from video stream.

--- a/service/service.cpp
+++ b/service/service.cpp
@@ -88,13 +88,14 @@ QString Service::decodeFromDescriptor(QDBusUnixFileDescriptor fd,
 
         if (buf != nullptr) {
             ZXing::DecodeHints hints;
-            hints.setFormats(ZXing::BarcodeFormat::QR_CODE);
+            hints.setFormats(ZXing::BarcodeFormat::QRCode);
             ZXing::ImageFormat format = convertFormat(pixelFormat);
+            hints.setTryInvert(true);
 
             if (format != ZXing::ImageFormat::None) {
                 ZXing::Result result = ZXing::ReadBarcode(
                 { buf, width, height, format}, hints);
-                response = QString::fromStdWString(result.text());
+                response = QString::fromStdString(result.text());
             } else {
                 qWarning() << "Input frame format is not supported by ZXing: "
                            << pixelFormat;

--- a/service/service.pro
+++ b/service/service.pro
@@ -2,6 +2,7 @@ TARGET = zxing-daemon
 
 QT = core dbus multimedia
 CONFIG += link_pkgconfig
+CONFIG += c++1z
 PKGCONFIG += zxing
 
 HEADERS = \


### PR DESCRIPTION
Needed to enable c++17 since zxing now requires that.

Depends on https://github.com/sailfishos/zxing/pull/3