### PR TITLE
[qr-filter] add QR encoding to daemon

### DIFF
--- a/service/dbus/org.amberapi.zxing.xml
+++ b/service/dbus/org.amberapi.zxing.xml
@@ -6,6 +6,7 @@
  * DBus service for interfacing with Application ID daemon.
  * Copyright (C) 2013 - 2020 Jolla Ltd.
  * Copyright (C) 2020 Open Mobile Platform LLC.
+ * Copyright (C) 2025 Peter G. (nephros)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -32,6 +33,14 @@
       <arg direction="in" type="i" name="width"/>
       <arg direction="in" type="i" name="height"/>
       <arg direction="in" type="i" name="pixelFormat"/>
+    </method>
+    <method name="encodeToDescriptor">
+      <arg direction="out" type="b" name="result"/>
+      <arg direction="in" type="h" name="descriptor"/>
+      <arg direction="in" type="s" name="text"/>
+      <arg direction="in" type="i" name="width"/>
+      <arg direction="in" type="i" name="height"/>
+      <arg direction="in" type="i" name="margin"/>
     </method>
     <method name="quit">
     </method>

--- a/service/service.cpp
+++ b/service/service.cpp
@@ -20,11 +20,35 @@
 #include <ZXing/DecodeHints.h>
 #include <ZXing/Result.h>
 
+#include <QImage>
+#include <BitMatrix.h>
+#include <BitMatrixIO.h>
+#include <ZXing/CharacterSet.h>
+#include <ZXing/MultiFormatWriter.h>
+
 #include <unistd.h>
 #include <sys/mman.h>
 
 const char *SERVICE_NAME = "org.amberapi.zxing";
 const char *OBJECT_PATH = "/org/amberapi/zxing";
+
+ZXing::BitMatrix textToMatrix(QString text, int width, int height, int margin, ZXing::BarcodeFormat format=ZXing::BarcodeFormat::QRCode)
+{
+    ZXing::MultiFormatWriter writer(format);
+    writer.setEncoding(ZXing::CharacterSet::UTF8);
+    if (margin >= 0) {
+        writer.setMargin(margin);
+    }
+    return writer.encode(text.toStdString(), width, height);
+}
+
+QImage textToImage(QString text, int width, int height, int margin)
+{
+    ZXing::BitMatrix matrix = textToMatrix(text, width, height, margin);
+    auto bitmap = ZXing::ToMatrix<uint8_t>(matrix);
+    QImage image = QImage(bitmap.data(), bitmap.width(), bitmap.height(), bitmap.width(), QImage::Format::Format_Grayscale8).copy();
+    return image;
+}
 
 Service::Service(QObject *parent)
     : QObject(parent),
@@ -111,7 +135,27 @@ QString Service::decodeFromDescriptor(QDBusUnixFileDescriptor fd,
     return response;
 }
 
+bool Service::encodeToDescriptor(const QDBusUnixFileDescriptor &fd,
+                             const QString &text, int width, int height, int margin)
+{
+    m_autoclose.stop();
+    bool response = false;
+    QImage image = textToImage(text, width, height, margin);
+    QFile mf;
+    if (mf.open(fd.fileDescriptor(), QIODevice::WriteOnly)) {
+        response = image.save(&mf, "PNG");
+        if (!response) {
+            qWarning() << "QImage::save failed.";
+        }
+    } else {
+        qWarning() << "open():" << mf.error();
+    }
+    m_autoclose.start();
+    return response;
+}
+
 void Service::quit()
 {
     QCoreApplication::quit();
 }
+

--- a/service/service.h
+++ b/service/service.h
@@ -10,6 +10,7 @@
 #include <QDBusContext>
 #include <QDBusUnixFileDescriptor>
 #include <QTimer>
+#include <QString>
 
 class Service: public QObject, public QDBusContext
 {
@@ -22,6 +23,8 @@ public:
 public slots:
     QString decodeFromDescriptor(QDBusUnixFileDescriptor fd,
             uint size, int width, int height, int pixelFormat);
+    bool    encodeToDescriptor(const QDBusUnixFileDescriptor &fd,
+            const QString &text, int width, int height, int margin);
     void quit();
 
 private:


### PR DESCRIPTION
Adds a QR encoding capability to the deamon.

Base for an upcoming QML Image Provider plugin, or QrEncode QML type.

Generates regular QRCode image for now, but could be extended to support other
types supported by ZXing.

